### PR TITLE
feat: list books by category id

### DIFF
--- a/src/main/java/com/guilhermeramos31/springbootjuniorcase/controller/CategoryController.java
+++ b/src/main/java/com/guilhermeramos31/springbootjuniorcase/controller/CategoryController.java
@@ -1,5 +1,6 @@
 package com.guilhermeramos31.springbootjuniorcase.controller;
 
+import com.guilhermeramos31.springbootjuniorcase.model.book.dto.BookResponseDTO;
 import com.guilhermeramos31.springbootjuniorcase.model.category.dto.CategoryPaginationRequestDTO;
 import com.guilhermeramos31.springbootjuniorcase.model.category.dto.CategoryPaginationResponseDTO;
 import com.guilhermeramos31.springbootjuniorcase.model.category.dto.CategoryRequestDTO;
@@ -14,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @Tag(name = "Category")
@@ -64,5 +66,10 @@ public class CategoryController {
         headers.add(totalPages, String.valueOf(category.getTotalPages()));
 
         return ResponseEntity.ok().headers(headers).body(category);
+    }
+
+    @GetMapping("/{id}/books")
+    public ResponseEntity<List<BookResponseDTO>> getBook(@PathVariable Long id) {
+        return ResponseEntity.ok().body(categoryService.findBookByCategoryId(id));
     }
 }

--- a/src/main/java/com/guilhermeramos31/springbootjuniorcase/services/category/CategoryServiceImpl.java
+++ b/src/main/java/com/guilhermeramos31/springbootjuniorcase/services/category/CategoryServiceImpl.java
@@ -67,7 +67,7 @@ public class CategoryServiceImpl implements CategoryService {
 
     @Override
     public List<BookResponseDTO> findBookByCategoryId(long id) {
-        var  category = categoryRepository.findById(id).orElseThrow(()-> new EntityNotFoundException("Category not found"));
+        var category = categoryRepository.findById(id).orElseThrow(()-> new EntityNotFoundException("Category not found"));
 
         return category.getBooks().stream()
                 .map(bookMapper::toDTO)

--- a/src/main/java/com/guilhermeramos31/springbootjuniorcase/services/category/CategoryServiceImpl.java
+++ b/src/main/java/com/guilhermeramos31/springbootjuniorcase/services/category/CategoryServiceImpl.java
@@ -1,5 +1,7 @@
 package com.guilhermeramos31.springbootjuniorcase.services.category;
 
+import com.guilhermeramos31.springbootjuniorcase.model.book.dto.BookResponseDTO;
+import com.guilhermeramos31.springbootjuniorcase.model.book.mapper.BookMapper;
 import com.guilhermeramos31.springbootjuniorcase.model.category.Category;
 import com.guilhermeramos31.springbootjuniorcase.model.category.dto.CategoryPaginationRequestDTO;
 import com.guilhermeramos31.springbootjuniorcase.model.category.dto.CategoryPaginationResponseDTO;
@@ -15,11 +17,15 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class CategoryServiceImpl implements CategoryService {
     private final CategoryRepository categoryRepository;
     private final CategoryMapper mapper;
+    private final BookMapper bookMapper;
 
     @Override
     public CategoryResponseDTO create(CategoryRequestDTO categoryRequestDTO) {
@@ -57,5 +63,14 @@ public class CategoryServiceImpl implements CategoryService {
     @Override
     public Category getCategoryById(long id) {
         return categoryRepository.findById(id).orElseThrow(()-> new EntityNotFoundException("Category not found"));
+    }
+
+    @Override
+    public List<BookResponseDTO> findBookByCategoryId(long id) {
+        var  category = categoryRepository.findById(id).orElseThrow(()-> new EntityNotFoundException("Category not found"));
+
+        return category.getBooks().stream()
+                .map(bookMapper::toDTO)
+                .collect(Collectors.toList()) ;
     }
 }

--- a/src/main/java/com/guilhermeramos31/springbootjuniorcase/services/category/interfaces/CategoryService.java
+++ b/src/main/java/com/guilhermeramos31/springbootjuniorcase/services/category/interfaces/CategoryService.java
@@ -1,13 +1,17 @@
 package com.guilhermeramos31.springbootjuniorcase.services.category.interfaces;
 
+import com.guilhermeramos31.springbootjuniorcase.model.book.dto.BookResponseDTO;
 import com.guilhermeramos31.springbootjuniorcase.model.category.Category;
 import com.guilhermeramos31.springbootjuniorcase.model.category.dto.CategoryPaginationRequestDTO;
 import com.guilhermeramos31.springbootjuniorcase.model.category.dto.CategoryPaginationResponseDTO;
 import com.guilhermeramos31.springbootjuniorcase.model.category.dto.CategoryRequestDTO;
 import com.guilhermeramos31.springbootjuniorcase.model.category.dto.CategoryResponseDTO;
 
+import java.util.List;
+
 public interface CategoryService {
     CategoryResponseDTO create(CategoryRequestDTO categoryRequestDTO);
     CategoryPaginationResponseDTO findAll(CategoryPaginationRequestDTO pagination);
     Category getCategoryById(long category);
+    List<BookResponseDTO> findBookByCategoryId(long id);
 }


### PR DESCRIPTION
This pull request introduces a new feature to retrieve books by category ID, along with necessary updates to the `CategoryController`, `CategoryServiceImpl`, and `CategoryService` interface. The changes include the addition of a new endpoint, service method, and supporting code to enable this functionality.

### Feature: Retrieve books by category ID
#### Controller updates:
* Added a new `@GetMapping("/{id}/books")` endpoint in `CategoryController` to fetch books associated with a specific category by its ID.

#### Service layer updates:
* Added a new method `findBookByCategoryId(long id)` in `CategoryServiceImpl` to retrieve books for a given category ID using the `CategoryRepository` and map them to `BookResponseDTO` using `BookMapper`.
* Updated `CategoryService` interface to declare the new method `findBookByCategoryId(long id)`.

#### Supporting changes:
* Imported `BookResponseDTO` and `BookMapper` in `CategoryServiceImpl` to facilitate mapping of book entities to DTOs. [[1]](diffhunk://#diff-282c173e849f5611870140aff74e493d87ec9cbb670f275f2868b53b21cdb428R3-R4) [[2]](diffhunk://#diff-282c173e849f5611870140aff74e493d87ec9cbb670f275f2868b53b21cdb428R20-R28)
* Imported `BookResponseDTO` in `CategoryController` for use in the new endpoint response. [[1]](diffhunk://#diff-f3a632f23816a477a571addcd2f7b2359cd8515388d59241c6a3280e76322546R3) [[2]](diffhunk://#diff-f3a632f23816a477a571addcd2f7b2359cd8515388d59241c6a3280e76322546R18)