### PR TITLE
feat: add global exception handler for exceptions

### DIFF
--- a/src/main/java/com/guilhermeramos31/springbootjuniorcase/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/guilhermeramos31/springbootjuniorcase/exception/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package com.guilhermeramos31.springbootjuniorcase.exception;
 
+import jakarta.persistence.EntityExistsException;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.PersistenceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,24 +15,46 @@ import java.time.LocalDateTime;
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
+    private ResponseEntity<ErrorResponse> buildErrorResponse(String exceptionMessage, HttpStatus status, String defaultMsg) {
+        var message = (exceptionMessage != null && !exceptionMessage.isBlank()) ? exceptionMessage : defaultMsg;
 
-    @ExceptionHandler({MethodArgumentNotValidException.class})
-    public ResponseEntity<ErrorResponse> handlerArgumentNotValidException(MethodArgumentNotValidException exception) {
         var error = new ErrorResponse();
-        var httpStatus = HttpStatus.BAD_REQUEST;
-
-        var fieldError = exception.getFieldError();
-        var message = (fieldError != null && fieldError.getDefaultMessage() != null)
-                ? fieldError.getDefaultMessage()
-                : "Erro de validação genérico";
-
         error.setMessage(message);
-        error.setStatus(httpStatus.value());
-        error.setCode(httpStatus.name());
+        error.setStatus(status.value());
+        error.setCode(status.name());
         error.setTimestamp(LocalDateTime.now());
 
-        return ResponseEntity
-                .status(httpStatus)
-                .body(error);
+        return ResponseEntity.status(status).body(error);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException exception) {
+        var fieldError = exception.getFieldError();
+        var defaultMessage = "Validation error";
+        var message = (fieldError != null && fieldError.getDefaultMessage() != null)
+                ? fieldError.getDefaultMessage()
+                : defaultMessage;
+
+        return buildErrorResponse(message, HttpStatus.BAD_REQUEST, defaultMessage);
+    }
+
+    @ExceptionHandler({EntityNotFoundException.class})
+    public ResponseEntity<ErrorResponse> handlerEntityNotFoundException(EntityNotFoundException exception) {
+        return buildErrorResponse(exception.getMessage(), HttpStatus.NOT_FOUND, "Entity not found");
+    }
+
+    @ExceptionHandler({IllegalArgumentException.class})
+    public ResponseEntity<ErrorResponse> handlerIllegalArgumentException(IllegalArgumentException exception) {
+        return buildErrorResponse(exception.getMessage(), HttpStatus.BAD_REQUEST, "Invalid request");
+    }
+
+    @ExceptionHandler({EntityExistsException.class})
+    public ResponseEntity<ErrorResponse> handlerEntityExistsException(EntityExistsException exception) {
+        return buildErrorResponse(exception.getMessage(), HttpStatus.CONFLICT, "Entity already exists");
+    }
+
+    @ExceptionHandler({Throwable.class})
+    public ResponseEntity<ErrorResponse> handlerException(Throwable exception) {
+        return buildErrorResponse(exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error");
     }
 }

--- a/src/main/java/com/guilhermeramos31/springbootjuniorcase/services/category/CategoryServiceImpl.java
+++ b/src/main/java/com/guilhermeramos31/springbootjuniorcase/services/category/CategoryServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.sql.SQLException;
 import java.util.List;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
This pull request introduces enhancements to the global exception handling mechanism in the application and includes minor updates to the `CategoryServiceImpl` class. The most significant changes involve refactoring the `GlobalExceptionHandler` class to improve code reuse and adding handlers for new exception types.

### Improvements to exception handling:

- **Refactored `GlobalExceptionHandler` class**:
  - Introduced a reusable `buildErrorResponse` method to streamline the creation of error responses. This method ensures consistent formatting of error messages, HTTP status codes, and timestamps.
  - Added exception handlers for `EntityNotFoundException`, `IllegalArgumentException`, `EntityExistsException`, and a generic `Throwable` to provide more comprehensive error handling across the application.
  - Updated the handler for `MethodArgumentNotValidException` to use the new `buildErrorResponse` method and replaced hardcoded messages with a default message for validation errors.

- **Imported additional exception classes**:
  - Added imports for `EntityExistsException`, `EntityNotFoundException`, and `PersistenceException` to support the new exception handlers.

### Minor updates:

- **CategoryServiceImpl class**:
  - Added an import for `SQLException`, though no usage of this class is introduced in the current changes.